### PR TITLE
Add tests for movie settings routes

### DIFF
--- a/.phpunit.result.cache
+++ b/.phpunit.result.cache
@@ -1,1 +1,0 @@
-{"version":2,"defects":[],"times":{"Juzaweb\\Modules\\Movie\\Tests\\Feature\\ExampleTest::test_example":0.098,"Juzaweb\\Modules\\Movie\\Tests\\Feature\\MovieTest::test_movie_service_provider_registered":0.046,"Juzaweb\\Modules\\Movie\\Tests\\Feature\\MovieTest::test_movie_admin_route_exists":0.068}}

--- a/tests/Feature/SettingTest.php
+++ b/tests/Feature/SettingTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Juzaweb\Modules\Movie\Tests\Feature;
+
+use Juzaweb\Modules\Movie\Tests\TestCase;
+use Juzaweb\Modules\Core\Models\User;
+
+class SettingTest extends TestCase
+{
+    protected function createAdminUser()
+    {
+        $user = User::where('email', 'admin@test.com')->first();
+
+        if ($user) {
+            return $user;
+        }
+
+        $user = new User();
+        $user->name = 'Admin';
+        $user->email = 'admin@test.com';
+        $user->password = bcrypt('password');
+        $user->is_super_admin = 1;
+        $user->email_verified_at = now();
+        $user->save();
+
+        return $user;
+    }
+
+    public function test_movie_settings_index()
+    {
+        $response = $this->get(route('admin.movie-settings.index'));
+
+        $response->assertStatus(302); // Expect redirect to login if not authenticated
+    }
+
+    public function test_movie_settings_index_authenticated()
+    {
+        $user = $this->createAdminUser();
+
+        $response = $this->actingAs($user)->get(route('admin.movie-settings.index'));
+
+        $response->assertStatus(200);
+        $response->assertViewIs('movie::setting.index');
+    }
+
+    public function test_movie_settings_update()
+    {
+        $user = $this->createAdminUser();
+
+        $response = $this->actingAs($user)->putJson(route('admin.movie-settings.update'), [
+            'tmdb_api_key' => 'test_api_key',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson(['success' => true]);
+
+        $this->assertDatabaseHas('settings', [
+            'code' => 'tmdb_api_key',
+            'value' => 'test_api_key',
+        ]);
+    }
+}


### PR DESCRIPTION
Added feature tests for `admin.movie-settings.index` and `admin.movie-settings.update` routes.
Tests cover:
- Unauthenticated access (redirect to login).
- Authenticated access (successful response).
- Updating settings via PUT request.
- Verification of database changes.

---
*PR created automatically by Jules for task [15513718460068547988](https://jules.google.com/task/15513718460068547988) started by @juzaweb*